### PR TITLE
[TASK] Require static_info_tables >= 6.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - make the TCA cacheable
 
 ### Changed
-- #1 Convert the locallang files to XLIFF
+- #3 require static_info_tables >= 6.3.7
+- #1 convert the locallang files to XLIFF
 - move the extension to GitHub
 - allow oelib up to 1.9.99
 - set 7.9.99 as maximum TYPO3 version

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "typo3/cms-core": "^6.2 || ^7.6",
         "typo3/cms-frontend": "^6.2 || ^7.6",
         "oliverklee/oelib": "^1.3.0",
-        "sjbr/static-info-tables": "^6.2.0"
+        "sjbr/static-info-tables": "^6.3.7"
     },
     "require-dev": {
         "helhum/typo3-composer-setup": "^0.5.1",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -37,7 +37,7 @@ $EM_CONF[$_EXTKEY] = array(
             'typo3' => '6.2.0-7.9.99',
             'oelib' => '1.3.0-1.9.99',
             'ameos_formidable' => '1.1.564-1.9.99',
-            'static_info_tables' => '6.2.0-',
+            'static_info_tables' => '6.3.7-',
         ),
         'conflicts' => array(
             'dbal' => '',


### PR DESCRIPTION
This is the earliest version available on Packagist.