### PR TITLE
[BUGFIX] Update the composer package name of static-info-tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - drop global variables from pi1_wizicon
 
 ### Fixed
+- Update the composer package name of static-info-tables (#53)
 - Add the missing required PHP extensions to the composer.json (#51)
 - Fix crash in the FE editor (#49)
 - Properly make hidden list view parts visible again if needed (#44, #48)

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "typo3/cms-core": "^6.2.0 || ^7.6.23",
         "typo3/cms-frontend": "^6.2.0 || ^7.6.23",
         "oliverklee/oelib": "^1.3.0",
-        "sjbr/static-info-tables": "^6.3.7"
+        "typo3-ter/static-info-tables": "^6.3.7"
     },
     "require-dev": {
         "helhum/typo3-composer-setup": "^0.5.1",


### PR DESCRIPTION
The old package sjbr/static-info-tables has been abandoned.
typo3-ter/static-info-tables should be used instead.