### PR TITLE
[CLEANUP] Drop the destructors

### DIFF
--- a/Mapper/class.tx_realty_Mapper_District.php
+++ b/Mapper/class.tx_realty_Mapper_District.php
@@ -40,16 +40,6 @@ class tx_realty_Mapper_District extends Tx_Oelib_DataMapper
     private $cacheByNameAndCityUid = [];
 
     /**
-     * Frees as much memory that has been used by this object as possible.
-     */
-    public function __destruct()
-    {
-        $this->cacheByNameAndCityUid = [];
-
-        parent::__destruct();
-    }
-
-    /**
      * Finds all districts that belong to a certain city.
      *
      * If $uid is zero, this function returns all districts without a city.

--- a/Mapper/class.tx_realty_Mapper_RealtyObject.php
+++ b/Mapper/class.tx_realty_Mapper_RealtyObject.php
@@ -34,16 +34,6 @@ class tx_realty_Mapper_RealtyObject extends Tx_Oelib_DataMapper
     private $cacheByObjectNumberAndObjectIdAndLanguage = [];
 
     /**
-     * Frees as much memory that has been used by this object as possible.
-     */
-    public function __destruct()
-    {
-        $this->cacheByObjectNumberAndObjectIdAndLanguage = [];
-
-        parent::__destruct();
-    }
-
-    /**
      * Returns the number of realty objects in the city $city.
      *
      * @param tx_realty_Model_City $city the city for which to count the objects

--- a/Model/class.tx_realty_Model_RealtyObject.php
+++ b/Model/class.tx_realty_Model_RealtyObject.php
@@ -244,16 +244,6 @@ class tx_realty_Model_RealtyObject extends tx_realty_Model_AbstractTitledModel i
     }
 
     /**
-     * Destructor.
-     */
-    public function __destruct()
-    {
-        unset($this->charsetConversion, $this->owner, $this->images);
-
-        parent::__destruct();
-    }
-
-    /**
      * Gets allowed image file extensions.
      *
      * @return string[] lowercased allowed image file extensions, might be empty

--- a/lib/class.tx_realty_domDocumentConverter.php
+++ b/lib/class.tx_realty_domDocumentConverter.php
@@ -186,14 +186,6 @@ class tx_realty_domDocumentConverter
     }
 
     /**
-     * Frees as much memory that has been used by this object as possible.
-     */
-    public function __destruct()
-    {
-        unset($this->rawRealtyData, $this->fileNameMapper);
-    }
-
-    /**
      * Handles the conversion of a DOMDocument and returns the realty records
      * found in the DOMDocument as values of an array. Each of this values is an
      * array with column names like in the database table 'tx_realty_objects' as

--- a/lib/class.tx_realty_fileNameMapper.php
+++ b/lib/class.tx_realty_fileNameMapper.php
@@ -36,14 +36,6 @@ class tx_realty_fileNameMapper
     }
 
     /**
-     * Destructor.
-     */
-    public function __destruct()
-    {
-        unset($this->fileNames, $this->destinationPath);
-    }
-
-    /**
      * Returns the unique file name for the provided file name within the
      * destination directory and maps both names internally.
      *

--- a/lib/class.tx_realty_openImmoImport.php
+++ b/lib/class.tx_realty_openImmoImport.php
@@ -106,14 +106,6 @@ class tx_realty_openImmoImport
     }
 
     /**
-     * Frees as much memory that has been used by this object as possible.
-     */
-    public function __destruct()
-    {
-        unset($this->globalConfiguration, $this->importedXml, $this->realtyObject, $this->fileNameMapper);
-    }
-
-    /**
      * Extracts ZIP archives from an absolute path of a directory and inserts
      * realty records to database:
      * If the directory, specified in the EM configuration, exists and ZIP

--- a/lib/class.tx_realty_translator.php
+++ b/lib/class.tx_realty_translator.php
@@ -41,14 +41,6 @@ class tx_realty_translator
     }
 
     /**
-     * The destructor.
-     */
-    public function __destruct()
-    {
-        unset($this->languageService);
-    }
-
-    /**
      * Retrieves the localized string for the local language key $key.
      *
      * @param string $key the local language key for which to return the value, must not be empty

--- a/pi1/class.tx_realty_frontEndForm.php
+++ b/pi1/class.tx_realty_frontEndForm.php
@@ -76,16 +76,6 @@ class tx_realty_frontEndForm extends tx_realty_pi1_FrontEndView
     }
 
     /**
-     * Frees as much memory that has been used by this object as possible.
-     */
-    public function __destruct()
-    {
-        unset($this->formCreator, $this->realtyObject);
-
-        parent::__destruct();
-    }
-
-    /**
      * Instantiates $this->formCreator (if it hasn't been created yet).
      *
      * This function does nothing if this object is running in test mode.

--- a/pi1/class.tx_realty_pi1_AbstractListView.php
+++ b/pi1/class.tx_realty_pi1_AbstractListView.php
@@ -113,15 +113,6 @@ abstract class tx_realty_pi1_AbstractListView extends tx_realty_pi1_FrontEndView
     }
 
     /**
-     * Frees as much memory that has been used by this object as possible.
-     */
-    public function __destruct()
-    {
-        unset($this->formatter, $this->realtyObject);
-        parent::__destruct();
-    }
-
-    /**
      * Sets the realty object of the actual row.
      *
      * @param int $realtyObjectUid the uid of the Realty object of the actual row, must be >= 0

--- a/pi1/class.tx_realty_pi1_GoogleMapsView.php
+++ b/pi1/class.tx_realty_pi1_GoogleMapsView.php
@@ -53,15 +53,6 @@ class tx_realty_pi1_GoogleMapsView extends tx_realty_pi1_FrontEndView
     }
 
     /**
-     * Frees as much memory that has been used by this object as possible.
-     */
-    public function __destruct()
-    {
-        unset($this->realtyObject, $this->mapMarkers);
-        parent::__destruct();
-    }
-
-    /**
      * Returns the HTML for Google Maps.
      *
      * If none of the objects on the current page have coordinates, the result

--- a/tests/FrontEnd/ContactFormTest.php
+++ b/tests/FrontEnd/ContactFormTest.php
@@ -73,7 +73,7 @@ class tx_realty_FrontEnd_ContactFormTest extends Tx_Phpunit_TestCase
             'request'
         );
 
-        $this->message = $this->getMock(MailMessage::class, ['send', '__destruct']);
+        $this->message = $this->getMock(MailMessage::class, ['send']);
         GeneralUtility::addInstance(MailMessage::class, $this->message);
     }
 

--- a/tests/FrontEnd/EditorTest.php
+++ b/tests/FrontEnd/EditorTest.php
@@ -61,7 +61,7 @@ class tx_realty_FrontEnd_EditorTest extends Tx_Phpunit_TestCase
             true
         );
 
-        $this->message = $this->getMock(MailMessage::class, ['send', '__destruct']);
+        $this->message = $this->getMock(MailMessage::class, ['send']);
         GeneralUtility::addInstance(MailMessage::class, $this->message);
     }
 

--- a/tests/Import/OpenImmoImportTest.php
+++ b/tests/Import/OpenImmoImportTest.php
@@ -79,7 +79,7 @@ class tx_realty_Import_OpenImmoImportTest extends Tx_Phpunit_TestCase
         $this->fixture = new tx_realty_openImmoImportChild(true);
         $this->setupStaticConditions();
 
-        $this->message = $this->getMock(MailMessage::class, ['send', '__destruct']);
+        $this->message = $this->getMock(MailMessage::class, ['send']);
         GeneralUtility::addInstance(MailMessage::class, $this->message);
     }
 


### PR DESCRIPTION
With current versions of PHP, the garbage collector does not need
the unsetting of member variables anymore.