### PR TITLE
[BUGFIX] Re-add missing district drop-down to the FE editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - drop global variables from pi1_wizicon
 
 ### Fixed
+- Re-add missing district drop-down to the FE editor (#72)
 - Adapt the FE image upload to mkforms (#67)
 - Properly encode alert texts (#66)
 - Remove double labels for radiobutton groups (#65)

--- a/Configuration/TypoScript/Forms/Editor.txt
+++ b/Configuration/TypoScript/Forms/Editor.txt
@@ -255,6 +255,53 @@ plugin.tx_realty_pi1.editor {
             }
         }
 
+        district = renderlet:LISTBOX
+        district {
+            name = district
+            label = LLL:EXT:realty/Resources/Private/Language/locallang_db.xlf:tx_realty_objects.district
+            data {
+                items {
+                    10 {
+                        caption =
+                        value = 0
+                    }
+                }
+                userobj {
+                    extension = this
+                    method = populateDistrictList
+                }
+            }
+            validators {
+                10 = validator:STANDARD
+                10.custom {
+                    userobj {
+                        extension = this
+                        method = checkKeyExistsInTable
+                        params {
+                            10 {
+                                name = table
+                                value = tx_realty_districts
+                            }
+                        }
+                    }
+                    message.userobj {
+                        extension = this
+                        method = getMessageForRealtyObjectField
+                        params {
+                            10 {
+                                name = fieldName
+                                value = tx_realty_districts
+                            }
+                            20 {
+                                name = label
+                                value = message_value_not_allowed
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         newDistrictButton = renderlet:BUTTON
         newDistrictButton {
             name = newDistrictButton


### PR DESCRIPTION
The district drop-down accidentally had been left out when converting
the FE editor configuration from XML to TypoScript.