### PR TITLE
[BUGFIX] Allow an empty construction year again in the TCEforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Disable the old BE module in TYPO3 8.7 (#97)
 
 ### Fixed
+- Allow an empty construction year again in the TCEforms (#110)
 - Increase the allowed image and document size to 4 MB (#109)
 - Fix most deprecation warnings in TYPO3 7.6 (#108)
 - Fix code inspection warnings (#107)

--- a/Configuration/TCA/tx_realty_objects.php
+++ b/Configuration/TCA/tx_realty_objects.php
@@ -809,9 +809,9 @@ $tca = [
                 'size' => 4,
                 'max' => 4,
                 'eval' => 'int',
-                'checkbox' => '0',
+                'checkbox' => '',
                 'range' => [
-                    'lower' => 1400,
+                    'lower' => 0,
                     'upper' => 2100,
                 ],
                 'default' => 0,


### PR DESCRIPTION
The lower limit of 1400 did not allow an empty year. So we need
to drop the lower limit.