### PR TITLE
[TASK] Small updates to the manual

### DIFF
--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -16,12 +16,6 @@
 Introduction
 ------------
 
-If you like this extension, please submit a rating for it in the TER.
-
-**This manual is about the development version of the Realty
-Manager.**
-
-
 .. toctree::
    :maxdepth: 5
    :titlesonly:

--- a/Documentation/KeepingUp-to-dateAndGettingSupport/FoundABug/Index.rst
+++ b/Documentation/KeepingUp-to-dateAndGettingSupport/FoundABug/Index.rst
@@ -32,3 +32,10 @@ when reporting a bug:
 - what you expect to happen
 
 - what actually happens instead
+
+
+Get a service level agreement (SLA)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This extension is part of the service level agreements (SLAs) offered
+by the `coders.care project <https://coders.care/>`_.


### PR DESCRIPTION
- Drop obsolete sentence that the manual is about the development version
  of the extension.

- Don't recommend TER ratings anymore (as this feature has been dropped from
  TER).

- Mention coders.care.

[ci skip]