### PR TITLE
[CLEANUP] Simplify the TCA for images and documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,24 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+## 1.0.1
+
+### Added
 - Provide an API key for Google Maps (#47, #101)
 - Auto-release to the TER (#98)
 
 ### Changed
+- Simplify the TCA for images and documents (#116)
 - Clean up the JavaScript (#114)
-
-### Deprecated
 
 ### Removed
 - Disable the old BE module in TYPO3 8.7 (#97)

--- a/Configuration/TCA/tx_realty_documents.php
+++ b/Configuration/TCA/tx_realty_documents.php
@@ -11,14 +11,11 @@ $tca = [
         'languageField' => 'sys_language_uid',
         'transOrigPointerField' => 'l18n_parent',
         'transOrigDiffSourceField' => 'l18n_diffsource',
-        'default_sortby' => 'ORDER BY object',
+        'default_sortby' => 'ORDER BY sorting',
         'delete' => 'deleted',
         'hideTable' => true,
         'enablecolumns' => [],
         'iconfile' => 'EXT:realty/icons/icon_tx_realty_documents.gif',
-    ],
-    'interface' => [
-        'showRecordFieldList' => 'sys_language_uid,l18n_parent,l18n_diffsource,title,filename',
     ],
     'columns' => [
         'sys_language_uid' => [
@@ -53,16 +50,8 @@ $tca = [
             ],
         ],
         'object' => [
-            'exclude' => 0,
-            'label' => '',
             'config' => [
-                'type' => 'select',
-                'renderType' => 'selectSingle',
-                'foreign_table' => 'tx_realty_objects',
-                'items' => [['', '0']],
-                'size' => 1,
-                'minitems' => 0,
-                'maxitems' => 1,
+                'type' => 'passthrough',
             ],
         ],
         'title' => [

--- a/Configuration/TCA/tx_realty_images.php
+++ b/Configuration/TCA/tx_realty_images.php
@@ -11,16 +11,13 @@ $tca = [
         'languageField' => 'sys_language_uid',
         'transOrigPointerField' => 'l18n_parent',
         'transOrigDiffSourceField' => 'l18n_diffsource',
-        'default_sortby' => 'ORDER BY object',
+        'default_sortby' => 'ORDER BY sorting',
         'delete' => 'deleted',
         'hideTable' => true,
         'enablecolumns' => [
             'disabled' => 'hidden',
         ],
         'iconfile' => 'EXT:realty/icons/icon_tx_realty_images.gif',
-    ],
-    'interface' => [
-        'showRecordFieldList' => 'sys_language_uid,l18n_parent,l18n_diffsource,hidden,caption,image,thumbnail,position',
     ],
     'columns' => [
         'sys_language_uid' => [
@@ -63,16 +60,8 @@ $tca = [
             ],
         ],
         'object' => [
-            'exclude' => 0,
-            'label' => '',
             'config' => [
-                'type' => 'select',
-                'renderType' => 'selectSingle',
-                'foreign_table' => 'tx_realty_objects',
-                'items' => [['', '0']],
-                'size' => 1,
-                'minitems' => 0,
-                'maxitems' => 1,
+                'type' => 'passthrough',
             ],
         ],
         'caption' => [


### PR DESCRIPTION
The relation to the parent object can be "passthrough", and there is no
need for a configuration for the fields to be visible in the list view
as neither images nor documents will be directly visible in the list view.