### PR TITLE
[BUGFIX] Keep the BE language when using the BE module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for TYPO3 6.2 and require TYPO3 >= 7.6 (#138)
 
 ### Fixed
+- Keep the BE language when using the BE module button (#164)
 - Fix SQL errors in MySQL strict mode (#142)
 
 ## 1.1.0

--- a/lib/class.tx_realty_openImmoImport.php
+++ b/lib/class.tx_realty_openImmoImport.php
@@ -2,6 +2,7 @@
 
 use TYPO3\CMS\Core\Mail\MailMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Lang\LanguageService;
 
 /**
  * This class imports ZIPs containing OpenImmo records.
@@ -96,6 +97,11 @@ class tx_realty_openImmoImport
     private $success = true;
 
     /**
+     * @var LanguageService
+     */
+    private $languageServiceBackup = null;
+
+    /**
      * Constructor.
      *
      * @param bool $isTestMode
@@ -135,6 +141,9 @@ class tx_realty_openImmoImport
      */
     public function importFromZip()
     {
+        $this->languageServiceBackup = $this->getLanguageService();
+        $GLOBALS['LANG'] = new LanguageService();
+
         $this->success = true;
 
         $this->addToLogEntry(date('Y-m-d G:i:s') . LF);
@@ -167,7 +176,17 @@ class tx_realty_openImmoImport
 
         $this->storeLogsAndClearTemporaryLog();
 
+        $GLOBALS['LANG'] = $this->languageServiceBackup;
+
         return $this->logEntry;
+    }
+
+    /**
+     * @return LanguageService
+     */
+    private function getLanguageService()
+    {
+        return $GLOBALS['LANG'];
     }
 
     /**


### PR DESCRIPTION
The language needs to stay the same on the result page instead of
becoming the language configured for the import result emails.