### PR TITLE
[BUGFIX] Also provide the extension icon in `Resources/`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop the checks for the zip_archive PHP extension (#175)
 
 ### Fixed
+- Also provide the extension icon in `Resources/` (#176)
 
 ## 2.0.0
 


### PR DESCRIPTION
This makes the icon visible in the EM in secure installations.

[ci skip]