### PR TITLE
[TASK] Stop using the charset conversion from the BE or FE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Stop using the charset conversion from the BE or FE (#178)
 
 ### Deprecated
 


### PR DESCRIPTION
The old kind of usage is deprecated in TYPO3 8.7.