### PR TITLE
[TASK] User higher UIDs in the fixture files

### DIFF
--- a/Tests/Functional/Fixtures/Attachments.xml
+++ b/Tests/Functional/Fixtures/Attachments.xml
@@ -25,7 +25,7 @@
         <uid>1</uid>
         <pid>1</pid>
         <uid_local>10</uid_local>
-        <uid_foreign>2</uid_foreign>
+        <uid_foreign>102</uid_foreign>
         <tablenames>tx_realty_objects</tablenames>
         <fieldname>attachments</fieldname>
         <l10n_diffsource/>
@@ -34,7 +34,7 @@
         <uid>2</uid>
         <pid>1</pid>
         <uid_local>11</uid_local>
-        <uid_foreign>2</uid_foreign>
+        <uid_foreign>102</uid_foreign>
         <tablenames>tx_realty_objects</tablenames>
         <fieldname>attachments</fieldname>
         <l10n_diffsource/>
@@ -43,7 +43,7 @@
         <uid>3</uid>
         <pid>1</pid>
         <uid_local>12</uid_local>
-        <uid_foreign>2</uid_foreign>
+        <uid_foreign>102</uid_foreign>
         <tablenames>tx_realty_objects</tablenames>
         <fieldname>attachments</fieldname>
         <l10n_diffsource/>

--- a/Tests/Functional/Fixtures/RealtyObjects.xml
+++ b/Tests/Functional/Fixtures/RealtyObjects.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <dataset>
     <tx_realty_objects>
-        <uid>1</uid>
+        <uid>101</uid>
         <title>A music house for house music</title>
     </tx_realty_objects>
     <tx_realty_objects>
-        <uid>2</uid>
+        <uid>102</uid>
         <attachments>3</attachments>
     </tx_realty_objects>
 </dataset>

--- a/Tests/Functional/FrontEnd/SingleView/DocumentsViewTest.php
+++ b/Tests/Functional/FrontEnd/SingleView/DocumentsViewTest.php
@@ -123,7 +123,7 @@ class DocumentsViewTest extends FunctionalTestCase
         $this->importDataSet(__DIR__ . '/../../Fixtures/Attachments.xml');
         $this->importDataSet(__DIR__ . '/../../Fixtures/RealtyObjects.xml');
 
-        $result = $this->subject->render(['showUid' => 2]);
+        $result = $this->subject->render(['showUid' => 102]);
 
         self::assertContains('some nice &amp; fine PDF document', $result);
     }

--- a/Tests/Functional/Mapper/RealtyObjectMapperTest.php
+++ b/Tests/Functional/Mapper/RealtyObjectMapperTest.php
@@ -50,7 +50,7 @@ class RealtyObjectMapperTest extends FunctionalTestCase
         $this->importDataSet(__DIR__ . '/../Fixtures/RealtyObjects.xml');
 
         /** @var \tx_realty_Model_RealtyObject $model */
-        $model = $this->subject->find(1);
+        $model = $this->subject->find(101);
 
         self::assertSame('A music house for house music', $model->getTitle());
     }

--- a/Tests/Functional/Model/RealtyObjectTest.php
+++ b/Tests/Functional/Model/RealtyObjectTest.php
@@ -61,7 +61,7 @@ class RealtyObjectTest extends FunctionalTestCase
         $this->importDataSet(__DIR__ . '/../Fixtures/RealtyObjects.xml');
 
         /** @var \tx_realty_Model_RealtyObject $model */
-        $model = $this->realtyObjectMapper->find(2);
+        $model = $this->realtyObjectMapper->find(102);
         $attachments = $model->getAttachments();
 
         self::assertGreaterThanOrEqual(1, $attachments);
@@ -79,7 +79,7 @@ class RealtyObjectTest extends FunctionalTestCase
         $this->importDataSet(__DIR__ . '/../Fixtures/RealtyObjects.xml');
 
         /** @var \tx_realty_Model_RealtyObject $model */
-        $model = $this->realtyObjectMapper->find(2);
+        $model = $this->realtyObjectMapper->find(102);
         $attachments = $model->getPdfAttachments();
 
         self::assertCount(1, $attachments);
@@ -97,7 +97,7 @@ class RealtyObjectTest extends FunctionalTestCase
         $this->importDataSet(__DIR__ . '/../Fixtures/RealtyObjects.xml');
 
         /** @var \tx_realty_Model_RealtyObject $model */
-        $model = $this->realtyObjectMapper->find(2);
+        $model = $this->realtyObjectMapper->find(102);
         $attachments = $model->getJpegAttachments();
 
         self::assertCount(1, $attachments);


### PR DESCRIPTION
This avoids UID conflicts with records created with the oelib
testing framework.