### PR TITLE
[FEATURE] Add RealtyObject.getAttachmentByBaseName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Add RealtyObject.getAttachmentByBaseName (#215)
 - Have DomDocumentConverter find general attachments (#214)
 - Use FAL for the FE image upload (#210)
 - Add RealtyObject.removeAttachmentByFileUid (#209)

--- a/Model/class.tx_realty_Model_RealtyObject.php
+++ b/Model/class.tx_realty_Model_RealtyObject.php
@@ -1168,6 +1168,30 @@ class tx_realty_Model_RealtyObject extends tx_realty_Model_AbstractTitledModel i
     }
 
     /**
+     * @param string $baseName must not be empty
+     *
+     * @return FileReference|null
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function getAttachmentByBaseName($baseName)
+    {
+        if ($baseName === '') {
+            throw new \InvalidArgumentException('$baseName must not be empty.', 1550514147);
+        }
+
+        $match = null;
+        foreach ($this->getAttachments() as $attachment) {
+            if ($attachment->getOriginalFile()->getName() === $baseName) {
+                $match = $attachment;
+                break;
+            }
+        }
+
+        return $match;
+    }
+
+    /**
      * Adds an attachment (reusing an existing FAL record if it exists).
      *
      * Note: This function does not persist this realty object yet.

--- a/Tests/Functional/Model/RealtyObjectTest.php
+++ b/Tests/Functional/Model/RealtyObjectTest.php
@@ -221,6 +221,68 @@ class RealtyObjectTest extends FunctionalTestCase
 
     /**
      * @test
+     * @expectedException \InvalidArgumentException
+     */
+    public function getAttachmentByBaseNameForEmptyBaseNameThrowsException()
+    {
+        $this->importDataSet(__DIR__ . '/../Fixtures/RealtyObjects.xml');
+
+        /** @var \tx_realty_Model_RealtyObject $subject */
+        $subject = $this->realtyObjectMapper->find(101);
+
+        $subject->getAttachmentByBaseName('');
+    }
+
+    /**
+     * @test
+     */
+    public function getAttachmentByBaseNameForNoAttachmentsReturnsNull()
+    {
+        $this->importDataSet(__DIR__ . '/../Fixtures/RealtyObjects.xml');
+
+        /** @var \tx_realty_Model_RealtyObject $subject */
+        $subject = $this->realtyObjectMapper->find(101);
+
+        $result = $subject->getAttachmentByBaseName('test.txt');
+
+        self::assertNull($result);
+    }
+
+    /**
+     * @test
+     */
+    public function getAttachmentByBaseNameForNoMatchReturnsNull()
+    {
+        $this->importDataSet(__DIR__ . '/../Fixtures/Attachments.xml');
+        $this->importDataSet(__DIR__ . '/../Fixtures/RealtyObjects.xml');
+
+        /** @var \tx_realty_Model_RealtyObject $subject */
+        $subject = $this->realtyObjectMapper->find(102);
+
+        $result = $subject->getAttachmentByBaseName('not-there.txt');
+
+        self::assertNull($result);
+    }
+
+    /**
+     * @test
+     */
+    public function getAttachmentByBaseNameForMatchReturnsMatchingReference()
+    {
+        $this->importDataSet(__DIR__ . '/../Fixtures/Attachments.xml');
+        $this->importDataSet(__DIR__ . '/../Fixtures/RealtyObjects.xml');
+
+        /** @var \tx_realty_Model_RealtyObject $subject */
+        $subject = $this->realtyObjectMapper->find(102);
+
+        $result = $subject->getAttachmentByBaseName('test.txt');
+
+        self::assertInstanceOf(FileReference::class, $result);
+        self::assertSame(12, $result->getOriginalFile()->getUid());
+    }
+
+    /**
+     * @test
      *
      * @expectedException \BadMethodCallException
      */


### PR DESCRIPTION
This will be helpful to avoid importing images multiple times when
updating a realty object during the OpenImmo import.