### PR TITLE
[BUGFIX] Keep virtual fields away from the database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop the checks for the zip_archive PHP extension (#175)
 
 ### Fixed
+- Keep virtual fields away from the database (#218)
 - Extract the imported ZIPs within typo3temp, not fileadmin (#217)
 - Set the sorting when adding attachments to realty objects (#212)
 - Keep the sorting when converting images and documents to FAL (#211)

--- a/Model/class.tx_realty_Model_RealtyObject.php
+++ b/Model/class.tx_realty_Model_RealtyObject.php
@@ -452,14 +452,14 @@ class tx_realty_Model_RealtyObject extends tx_realty_Model_AbstractTitledModel i
      */
     public function setData(array $realtyData)
     {
-        if (is_array($realtyData['images']) || is_array($realtyData['documents'])) {
-            $dataWithImages = $this->isolateImageRecords($realtyData);
-            $dataWithImagesAndDocuments = $this->isolateDocumentRecords(
-                $dataWithImages
-            );
+        $scrubbedData = $realtyData;
+        unset($scrubbedData['attached_files']);
+        if (is_array($scrubbedData['images']) || is_array($scrubbedData['documents'])) {
+            $dataWithImages = $this->isolateImageRecords($scrubbedData);
+            $dataWithImagesAndDocuments = $this->isolateDocumentRecords($dataWithImages);
             parent::setData($dataWithImagesAndDocuments);
         } else {
-            parent::setData($realtyData);
+            parent::setData($scrubbedData);
             $this->retrieveAttachedImages();
             $this->retrieveAttachedDocuments();
         }
@@ -625,12 +625,8 @@ class tx_realty_Model_RealtyObject extends tx_realty_Model_AbstractTitledModel i
      */
     public function writeToDatabase($overridePid = 0, $setOwner = false)
     {
-        // If contact_email is the only field, the object is assumed to be not
-        // loaded.
-        if ($this->isEmpty()
-            || ($this->existsKey('contact_email')
-                && count($this->getAllProperties()) === 1)
-        ) {
+        // If contact_email is the only field, the object is assumed to be not loaded.
+        if ($this->isEmpty() || ($this->existsKey('contact_email') && count($this->getAllProperties()) === 1)) {
             return 'message_object_not_loaded';
         }
 

--- a/Tests/LegacyUnit/Model/RealtyObjectTest.php
+++ b/Tests/LegacyUnit/Model/RealtyObjectTest.php
@@ -1245,6 +1245,24 @@ class tx_realty_Model_RealtyObjectTest extends \Tx_Phpunit_TestCase
 
     /**
      * @test
+     *
+     * @doesNotPerformAssertions
+     */
+    public function writeToDataBaseAfterSetDataWithAttachedFilesThrowsNoException()
+    {
+        $this->subject->setData(
+            [
+                'title' => 'new title',
+                'object_number' => self::$otherObjectNumber,
+                'openimmo_obid' => 'test-obid',
+                'attached_files' => [['title' => 'nice image', 'path' => '/tmp/image.jpg']],
+            ]
+        );
+        $this->subject->writeToDatabase();
+    }
+
+    /**
+     * @test
      */
     public function getPropertyWithNonExistingKeyWhenObjectLoaded()
     {


### PR DESCRIPTION
This avoids a crash when importing attachments from OpenImmo to FAL.