### PR TITLE
[BUGFIX] Remove obsolete directory creation "uploads/tx_realty/rte"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop the checks for the zip_archive PHP extension (#175)
 
 ### Fixed
+- Remove obsolete directory creation "uploads/tx_realty/rte" (#224, #225)
 - Use a valid OpenImmo file in the functional tests (#220, #221)
 - Extract the imported ZIPs within typo3temp, not fileadmin (#217, #219)
 - Use the correct path name when PHP-linting the tests (#192)

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -24,7 +24,7 @@ $EM_CONF[$_EXTKEY] = [
     ],
     'state' => 'stable',
     'uploadfolder' => true,
-    'createDirs' => 'uploads/tx_realty/,uploads/tx_realty/rte/',
+    'createDirs' => 'uploads/tx_realty/',
     'clearCacheOnLoad' => true,
     'author' => 'Oliver Klee',
     'author_email' => 'typo3-coding@oliverklee.de',


### PR DESCRIPTION
This is from the old RTE and not needed anymore.

[ci skip]