### PR TITLE
[CLEANUP] Drop unneeded data scrubbing during import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add new basic tests for the realty object model and mapper (#179)
 
 ### Changed
+- Drop unneeded data scrubbing during import (#238)
 - Stop using markTableAsDirty in the new functional tests (#232)
 - Move the RealURL configuration to Classes/ and namespace it (#228, #229)
 - Use fewer DB requests when accessing the realty model (#202, #203)

--- a/Model/class.tx_realty_Model_RealtyObject.php
+++ b/Model/class.tx_realty_Model_RealtyObject.php
@@ -353,25 +353,6 @@ class tx_realty_Model_RealtyObject extends tx_realty_Model_AbstractTitledModel i
     }
 
     /**
-     * Receives the data for a new realty object to load.
-     *
-     * The received data can either be a database result row or an array which
-     * has database column names as keys (may be empty). The data can also be a
-     * UID of an existent realty object to load from the database. If the data
-     * is of an invalid type, an empty array will be set.
-     *
-     * @param array $realtyData data for the realty object
-     *
-     * @return void
-     */
-    public function setData(array $realtyData)
-    {
-        $scrubbedData = $realtyData;
-        unset($scrubbedData['attached_files']);
-        parent::setData($scrubbedData);
-    }
-
-    /**
      * Sets the test mode. If this mode is enabled, all data written to the
      * database will receive the dummy record flag.
      *


### PR DESCRIPTION
The field `attached_images` does not lead to problems anymore and does
not need to be removed anymore before writing the data.