### PR TITLE
[TASK] Skip the DB cleanup in the new functional tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add new basic tests for the realty object model and mapper (#179)
 
 ### Changed
+- Skip the DB cleanup in the new functional tests (#249)
 - Require oelib >= 2.3.0 (#246)
 - Move the districts to within the cities with IRRE (#244)
 - Drop unneeded data scrubbing during import (#238)

--- a/Tests/Functional/FrontEnd/AbstractListViewTest.php
+++ b/Tests/Functional/FrontEnd/AbstractListViewTest.php
@@ -152,7 +152,7 @@ class AbstractListViewTest extends FunctionalTestCase
 
     protected function tearDown()
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/Functional/FrontEnd/AbstractViewTest.php
+++ b/Tests/Functional/FrontEnd/AbstractViewTest.php
@@ -43,7 +43,7 @@ class AbstractViewTest extends FunctionalTestCase
 
     protected function tearDown()
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/Functional/FrontEnd/ContactFormTest.php
+++ b/Tests/Functional/FrontEnd/ContactFormTest.php
@@ -96,7 +96,7 @@ class ContactFormTest extends FunctionalTestCase
         // Get any surplus instances added via GeneralUtility::addInstance.
         GeneralUtility::makeInstance(MailMessage::class);
 
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
         parent::tearDown();
     }
 

--- a/Tests/Functional/FrontEnd/EditorTest.php
+++ b/Tests/Functional/FrontEnd/EditorTest.php
@@ -91,7 +91,7 @@ class EditorTest extends FunctionalTestCase
 
         \tx_realty_cacheManager::purgeCacheManager();
 
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/Functional/FrontEnd/ImageUploadTest.php
+++ b/Tests/Functional/FrontEnd/ImageUploadTest.php
@@ -63,7 +63,7 @@ class ImageUploadTest extends FunctionalTestCase
         GeneralUtility::rmdir($this->getAbsoluteAttachmentsPath(), true);
         GeneralUtility::rmdir($this->getAbsoluteUploadsPath(), true);
 
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
         parent::tearDown();
     }
 

--- a/Tests/Functional/FrontEnd/SingleView/DocumentsViewTest.php
+++ b/Tests/Functional/FrontEnd/SingleView/DocumentsViewTest.php
@@ -58,7 +58,7 @@ class DocumentsViewTest extends FunctionalTestCase
 
     protected function tearDown()
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
         parent::tearDown();
     }
 

--- a/Tests/Functional/FrontEnd/SingleView/ImageThumbnailsViewTest.php
+++ b/Tests/Functional/FrontEnd/SingleView/ImageThumbnailsViewTest.php
@@ -86,7 +86,7 @@ class ImageThumbnailsViewTest extends FunctionalTestCase
         if (\file_exists($this->getPathOfTestFile())) {
             unlink($this->getPathOfTestFile());
         }
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
         parent::tearDown();
     }
 

--- a/Tests/Functional/Import/OpenImmoImportTest.php
+++ b/Tests/Functional/Import/OpenImmoImportTest.php
@@ -127,7 +127,7 @@ class OpenImmoImportTest extends FunctionalTestCase
         // Get any surplus instances added via GeneralUtility::addInstance.
         GeneralUtility::makeInstance(MailMessage::class);
 
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
         $this->deleteTestFolders();
 
         \tx_realty_cacheManager::purgeCacheManager();


### PR DESCRIPTION
The testing framework will flush the DB tables anyway, so there is no
need to do that ourselves.

This should improve test performance a bit.