### PR TITLE
[FEATURE] Make the language of the contact form email configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Make the language of the contact form email configuration (#251)
 - Replace slashes with dashes in the object number in the slug (#248)
 - Add the object number to the RealURL slug (#230, #231)
 - Import the attachments from OpenImmo to FAL (#222)

--- a/Configuration/TypoScript/FrontEndPlugin.txt
+++ b/Configuration/TypoScript/FrontEndPlugin.txt
@@ -92,6 +92,8 @@ plugin.tx_realty_pi1 {
     # default e-mail address for requests, used without validation if the record
     # has no valid contact_email
     defaultContactEmail =
+    # lowercase ISO code of the language to be used for the contact form email, e.g., "en" or "nl"
+    contactEmailLanguage =
     # e-mail address where to send a BCC of each request, leave empty to disable
     blindCarbonCopyAddress =
     # fields to show in the contact form

--- a/Documentation/Reference/((generated))/Index.rst
+++ b/Documentation/Reference/((generated))/Index.rst
@@ -297,6 +297,20 @@ override the corresponding value from TS Setup.**
 .. container:: table-row
 
    Property
+         contactEmailLanguage
+
+   Data type
+         string
+
+   Description
+         lowercase ISO code of the language to be used for the contact form email, e.g., "en" or "nl"
+
+   Default
+
+
+.. container:: table-row
+
+   Property
          blindCarbonCopyAddress
 
    Data type


### PR DESCRIPTION
The language now can be set via TypoScript:

plugin.tx_realty_pi1.contactEmailLanguage = de

If no language is configured, the current front-end language will be used
(which is the same behavior as before).