### PR TITLE
[CLEANUP] Drop TYPO3_PATH_ROOT from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,8 @@ services:
 
 env:
   global:
-  - COMPOSER_PROCESS_TIMEOUT=10000
   - DATABASE_USER=travis DATABASE_HOST=localhost DATABASE_PORT=3306 DATABASE_NAME=typo3 DATABASE_PASSWORD=''
   - typo3DatabaseUsername=travis typo3DatabaseHost=localhost typo3DatabaseName=typo3 typo3DatabasePassword=''
-  - TYPO3_PATH_ROOT=$PWD/.Build/public
 
 cache:
   directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Deprecated
 
 ### Removed
-- Drop unneeded Travis CI configuration settings (#272, #273, #274)
+- Drop unneeded Travis CI configuration settings (#272, #273, #274, #275)
 - Drop the TYPO3 package repository from composer.json (#263)
 
 ### Fixed


### PR DESCRIPTION
Also drop a redundant entry for the Composer timeout.