### PR TITLE
[BUGFIX] Do not cache vendor/ on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
 
 cache:
   directories:
-  - .Build/vendor
   - $HOME/.composer/cache
 
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Do not cache `vendor/` on Travis CI (#288)
 - Update the locations of the mkforms JavaScript includes (#287)
 
 ## 3.0.1


### PR DESCRIPTION
This causes too much trouble with version conflicts.

Caching the Composer cache should be enough anyway.