### PR TITLE
[BUGFIX] Fix crash when deleting inexistent object via OpenImmo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Fix crash when deleting inexistent object via OpenImmo (#295)
 - Move more tests to nimut/testing-framework (#294)
 - Catch exceptions in the BE module (#293)
 - Add tests for namespaced XML (#292)

--- a/lib/class.tx_realty_openImmoImport.php
+++ b/lib/class.tx_realty_openImmoImport.php
@@ -253,9 +253,10 @@ class tx_realty_openImmoImport
         foreach ($recordsToInsert as $record) {
             $this->writeToDatabase($record);
 
-            if (!$this->realtyObject->isDead()) {
+            $realtyObject = $this->realtyObject;
+            if (!$realtyObject->isDead() && !$realtyObject->isDeleted()) {
                 $this->importAttachments($record, $pathOfCurrentZipFile);
-                $savedRealtyObjects->add($this->realtyObject);
+                $savedRealtyObjects->add($realtyObject);
                 $emailData[] = $this->createEmailRawDataArray(
                     $this->getContactEmailFromRealtyObject(),
                     $this->getObjectNumberFromRealtyObject()


### PR DESCRIPTION
This crash occurs if the OpenImmo record has any attachments.