### PR TITLE
[BUGFIX] Add .0 version suffixes to PHP version requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Add `.0` version suffixes to PHP version requirements (#300)
 
 ## 3.0.2
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "source": "https://github.com/oliverklee/ext-realty"
     },
     "require": {
-        "php": "^5.5 || ~7.0 || ~7.1 || ~7.2",
+        "php": "^5.5.0 || ~7.0.0 || ~7.1.0 || ~7.2.0",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-libxml": "*",


### PR DESCRIPTION
Allowing PHP `~7.2` would allow PHP 7.5 as well (even if that version
most probably will not exist), while `~7.2.0` will not due to the way
the `~` operator for Composer version requirements works.