### PR TITLE
[Bugfix]: Fix the list plugin showing error in TYPO3 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Require oelib >= 3.5 for TYPO3 >= 8LTS (#309, #312, #319)
 - Move the CI from Travis to GitHub Actions (#306)
 - Change the default git branch from `master` to `main` (#305)
+- Move `ExtensionManagementUtility::addPlugin` call from  `ext_localconf.php` to `tt_content.php` for compatibility reasons.
 
 ### Deprecated
 

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,5 +1,33 @@
 <?php
 defined('TYPO3_MODE') or die('Access denied.');
 
-$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['realty_pi1'] = 'layout,select_key,pages,recursive';
-$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['realty_pi1'] = 'pi_flexform';
+$extPath = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('realty');
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+    'realty',
+    'Configuration/TypoScript/',
+    'Realty Manager'
+);
+
+\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
+    'OliverKlee.Realty',
+    'web',
+    'openImmo',
+    'bottom',
+    [
+        'OpenImmo' => 'index, import',
+    ],
+    [
+        'access' => 'group',
+        'icon' => 'EXT:realty/Resources/Public/Icons/BackEndModule.gif',
+        'labels' => 'LLL:EXT:realty/Resources/Private/Language/locallang_mod.xlf',
+        // hide the page tree
+        'navigationComponentId' => '',
+    ]
+);
+
+// Include base TSconfig setup
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
+    "@import 'EXT:realty/Configuration/TSconfig/ContentElementWizard.tsconfig'"
+);
+

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,33 +1,15 @@
 <?php
 defined('TYPO3_MODE') or die('Access denied.');
 
-$extPath = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('realty');
+$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['realty_pi1'] = 'layout,select_key,pages,recursive';
+$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['realty_pi1'] = 'pi_flexform';
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
-    'realty',
-    'Configuration/TypoScript/',
-    'Realty Manager'
-);
-
-\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
-    'OliverKlee.Realty',
-    'web',
-    'openImmo',
-    'bottom',
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(
     [
-        'OpenImmo' => 'index, import',
+        'LLL:EXT:realty/Resources/Private/Language/locallang_db.xlf:tt_content.list_type_pi1',
+        'realty_pi1',
+        'EXT:realty/Resources/Public/Images/ContentElement.gif',
     ],
-    [
-        'access' => 'group',
-        'icon' => 'EXT:realty/Resources/Public/Icons/BackEndModule.gif',
-        'labels' => 'LLL:EXT:realty/Resources/Private/Language/locallang_mod.xlf',
-        // hide the page tree
-        'navigationComponentId' => '',
-    ]
+    'list_type',
+    'realty'
 );
-
-// Include base TSconfig setup
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
-    "@import 'EXT:realty/Configuration/TSconfig/ContentElementWizard.tsconfig'"
-);
-

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,16 +1,6 @@
 <?php
 defined('TYPO3_MODE') or die('Access denied.');
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(
-    [
-        'LLL:EXT:realty/Resources/Private/Language/locallang_db.xlf:tt_content.list_type_pi1',
-        'realty_pi1',
-        'EXT:realty/Resources/Public/Images/ContentElement.gif',
-    ],
-    'list_type',
-    'realty'
-);
-
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43(
     'realty',
     'pi1/class.tx_realty_pi1.php',


### PR DESCRIPTION
The TYPO3 9 plugin shows an error, when the plugin is added as content element. 
The error says "Invalid value [realty_pi1]"
The error disappears when I move the call to the `ExtensionManagementUtility::addPlugin` method to the tt_content file. 
This PR moves the call to  `ExtensionManagementUtility::addPlugin`  tt_content.php file. 