### PR TITLE
[BUGFIX] Skip unit and functional tests on TYPO3 7.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,14 +99,15 @@ jobs:
       - name: "Run unit tests"
         run: "composer ci:tests:unit"
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - typo3-version: ^7.6
-            php-version: 7.0
-            composer-version: v1
-          - typo3-version: ^7.6
-            php-version: 7.1
-            composer-version: v1
+#          - typo3-version: ^7.6
+#            php-version: 7.0
+#            composer-version: v1
+#          - typo3-version: ^7.6
+#            php-version: 7.1
+#            composer-version: v1
           - typo3-version: ^8.7
             php-version: 7.0
             composer-version: v2
@@ -155,14 +156,15 @@ jobs:
           export typo3DatabasePassword="root";
           composer ci:tests:functional
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - typo3-version: ^7.6
-            php-version: 7.0
-            composer-version: v1
-          - typo3-version: ^7.6
-            php-version: 7.1
-            composer-version: v1
+#          - typo3-version: ^7.6
+#            php-version: 7.0
+#            composer-version: v1
+#          - typo3-version: ^7.6
+#            php-version: 7.1
+#            composer-version: v1
           - typo3-version: ^8.7
             php-version: 7.0
             composer-version: v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Allow Composer plugins for development (#333)
 - Stop using the core-provided whitespace constants (#321)
 - Fix a formatting-related PHP syntax error in a test (#317)
 - Restore PHP 5.5 compatibility in `composer.json` (#307)


### PR DESCRIPTION
This is a workaround for older versions of static_info_tables having
been yanked from Packagist (which fails the `composer install` steps
on TYPO3 7.6).